### PR TITLE
More thingies

### DIFF
--- a/site-new/src/components/home/Icons.astro
+++ b/site-new/src/components/home/Icons.astro
@@ -1,5 +1,5 @@
 ---
-import { getConfig, getVersionedDocsPath } from '../../libs/config'
+import { getConfig } from '../../libs/config'
 import CircleSquareIcon from '../icons/CircleSquareIcon.astro'
 ---
 

--- a/site-new/src/components/home/MastHead.astro
+++ b/site-new/src/components/home/MastHead.astro
@@ -1,0 +1,59 @@
+---
+import { getConfig, getVersionedDocsPath } from '../../libs/config'
+import Ads from '../Ads.astro'
+---
+
+<div class="bd-masthead mb-3" id="content">
+  <div class="container-xxl bd-gutter">
+    <div class="col-md-8 mx-auto text-center">
+      <a
+        class="d-flex flex-column flex-lg-row justify-content-center align-items-center mb-4 text-dark lh-sm text-decoration-none"
+        href="https://blog.getbootstrap.com/"
+      >
+        <strong class="d-sm-inline-block p-2 me-2 mb-2 mb-lg-0 rounded-3 masthead-notice">New in v5.3</strong>
+        <span class="text-body-secondary">Color mode support, expanded color palette, and more!</span>
+      </a>
+      <img
+        src="/brand/bootstrap-logo-shadow.png"
+        width="200"
+        height="165"
+        alt="Bootstrap"
+        class="d-none d-sm-block mx-auto mb-3"
+      />
+      <h1 class="mb-3 fw-semibold lh-1">Build fast, responsive sites with&nbsp;Bootstrap</h1>
+      <p class="lead mb-4">
+        Powerful, extensible, and feature-packed frontend toolkit. Build and customize with Sass, utilize prebuilt grid
+        system and components, and bring projects to life with powerful JavaScript plugins.
+      </p>
+      <div class="d-flex flex-column flex-lg-row align-items-md-stretch justify-content-md-center gap-3 mb-4">
+        <div class="d-inline-block v-align-middle fs-5">
+          <!-- TODO: replace by Astro stuff
+            * 'highlight' is a feature provided by Hugo
+            * We use Chroma style overriden in _syntax.scss
+          -->
+          <!-- {{ highlight (printf ("npm i bootstrap@%s") .Site.Params.current_version) "sh" "" }} -->
+        </div>
+        <a
+          href={getVersionedDocsPath('getting-started/introduction')}
+          class="btn btn-lg bd-btn-lg btn-bd-primary d-flex align-items-center justify-content-center fw-semibold"
+          onclick="ga('send', 'event', 'Jumbotron actions', 'Get started', 'Get started');"
+        >
+          <svg class="bi me-2" aria-hidden="true"><use xlink:href="#book-half"></use></svg>
+          Read the docs
+        </a>
+      </div>
+      <p class="text-body-secondary mb-0">
+        Currently <strong>v{getConfig().params.current_version}</strong>
+        <span class="px-1">&middot;</span>
+        <a href={getVersionedDocsPath('getting-started/download')} class="link-secondary">Download</a>
+        <span class="px-1">&middot;</span>
+        <a href="https://getbootstrap.com/docs/4.6/getting-started/introduction/" class="link-secondary text-nowrap"
+          >v4.6.x docs</a
+        >
+        <span class="px-1">&middot;</span>
+        <a href="/docs/versions/" class="link-secondary text-nowrap">All releases</a>
+      </p>
+      <Ads />
+    </div>
+  </div>
+</div>

--- a/site-new/src/components/home/Themes.astro
+++ b/site-new/src/components/home/Themes.astro
@@ -1,5 +1,5 @@
 ---
-import { getConfig, getVersionedDocsPath } from '../../libs/config'
+import { getConfig } from '../../libs/config'
 import DropletFillIcon from '../icons/DropletFillIcon.astro'
 ---
 

--- a/site-new/src/layouts/BaseLayout.astro
+++ b/site-new/src/layouts/BaseLayout.astro
@@ -1,8 +1,7 @@
 ---
 import type { MarkdownLayoutProps } from 'astro'
-import type { HTMLAttributes } from 'astro/types'
 import { getConfig } from '../libs/config'
-import type { Layout } from '../libs/layout'
+import type { Layout, LayoutOverridesHTMLAttributes } from '../libs/layout'
 import Head from '../components/head/Head.astro'
 import Header from '../components/header/Header.astro'
 import Scripts from '../components/Scripts.astro'
@@ -17,8 +16,8 @@ type Props = {
   // An object containing HTML attributes that can be overridden for some HTML elements used in the base layout keyed by
   // HTML element names.
   overrides?: {
-    body?: HTMLAttributes<'body'>
-    main?: HTMLAttributes<'main'>
+    body?: LayoutOverridesHTMLAttributes<'body'>
+    main?: LayoutOverridesHTMLAttributes<'main'>
   }
   // A string containing the robots meta tag content. If not set, the tag will not be rendered.
   robots?: string

--- a/site-new/src/layouts/BaseLayout.astro
+++ b/site-new/src/layouts/BaseLayout.astro
@@ -22,6 +22,9 @@ type Props = {
   }
   // A string containing the robots meta tag content. If not set, the tag will not be rendered.
   robots?: string
+  // An override for the page title. If not defined, the title will either be the content of the `title` frontmatter
+  // property when rendering a markdown page or default back to the one defined in the `config.yml` file.
+  title?: string
 } & MarkdownProps
 
 // The following props are automatically set by Astro (if defined) based on the markdown frontmatter when rendering a
@@ -39,7 +42,7 @@ const { frontmatter, layout, overrides, robots } = Astro.props
 
 // TODO(HiDeoo) This should probably be refactored to use a content collection when I get a better understanding of the
 // structure of the docs.
-const title = frontmatter?.title ?? getConfig().title
+const title = Astro.props.title ?? frontmatter?.title ?? getConfig().title
 const description = frontmatter?.description ?? getConfig().params.description
 const thumbnail = frontmatter?.thumbnail ? `img/${frontmatter.thumbnail}` : 'brand/bootstrap-social.png'
 

--- a/site-new/src/layouts/BaseLayout.astro
+++ b/site-new/src/layouts/BaseLayout.astro
@@ -1,4 +1,5 @@
 ---
+import type { MarkdownLayoutProps } from 'astro'
 import type { HTMLAttributes } from 'astro/types'
 import { getConfig } from '../libs/config'
 import type { Layout } from '../libs/layout'
@@ -7,19 +8,32 @@ import Header from '../components/header/Header.astro'
 import Scripts from '../components/Scripts.astro'
 import Footer from '../components/footer/Footer.astro'
 
-interface Props {
-  frontmatter?: {
-    description?: string
-    thumbnail?: string
-    title?: string
-  }
+// The following props can be directly passed to the base layout component from any page or layout extending it,
+// e.g. <BaseLayout layout="docs" robots="noindex" />.
+type Props = {
+  // A specific layout to use for the current page used to determine if some components should be rendered or not.
+  // Available layouts are defined in `src/libs/layout.ts`.
   layout?: Layout
+  // An object containing HTML attributes that can be overridden for some HTML elements used in the base layout keyed by
+  // HTML element names.
   overrides?: {
     body?: HTMLAttributes<'body'>
     main?: HTMLAttributes<'main'>
   }
+  // A string containing the robots meta tag content. If not set, the tag will not be rendered.
   robots?: string
-}
+} & MarkdownProps
+
+// The following props are automatically set by Astro (if defined) based on the markdown frontmatter when rendering a
+// markdown page. They can be accessed through the `Astro.props.frontmatter` object but note that they won't be set when
+// not rendering a markdown page.
+type MarkdownProps = Partial<
+  MarkdownLayoutProps<{
+    description?: string
+    thumbnail?: string
+    title?: string
+  }>
+>
 
 const { frontmatter, layout, overrides, robots } = Astro.props
 

--- a/site-new/src/layouts/BaseLayout.astro
+++ b/site-new/src/layouts/BaseLayout.astro
@@ -1,4 +1,5 @@
 ---
+import type { HTMLAttributes } from 'astro/types'
 import { getConfig } from '../libs/config'
 import type { Layout } from '../libs/layout'
 import Head from '../components/head/Head.astro'
@@ -13,16 +14,23 @@ interface Props {
     title?: string
   }
   layout?: Layout
+  overrides?: {
+    body?: HTMLAttributes<'body'>
+    main?: HTMLAttributes<'main'>
+  }
   robots?: string
 }
 
-const { frontmatter, layout, robots } = Astro.props
+const { frontmatter, layout, overrides, robots } = Astro.props
 
 // TODO(HiDeoo) This should probably be refactored to use a content collection when I get a better understanding of the
 // structure of the docs.
 const title = frontmatter?.title ?? getConfig().title
 const description = frontmatter?.description ?? getConfig().params.description
 const thumbnail = frontmatter?.thumbnail ? `img/${frontmatter.thumbnail}` : 'brand/bootstrap-social.png'
+
+const bodyProps = overrides?.body ?? {}
+const mainProps = overrides?.main ?? {}
 ---
 
 <!DOCTYPE html>
@@ -30,16 +38,10 @@ const thumbnail = frontmatter?.thumbnail ? `img/${frontmatter.thumbnail}` : 'bra
   <head>
     <Head description={description} layout={layout} robots={robots} thumbnail={thumbnail} title={title} />
   </head>
-  <body
-    ><!--TODO: handle {{ block "body_override" . }}<body>{{ end }} -->
-
+  <body {...bodyProps}>
     <Header layout={layout} title={title} />
 
-    <!-- TODO:
-			{{ block "main" . }}
-			{{ end }}
-		-->
-    <main>
+    <main {...mainProps}>
       <slot />
     </main>
 

--- a/site-new/src/layouts/DocsLayout.astro
+++ b/site-new/src/layouts/DocsLayout.astro
@@ -1,5 +1,23 @@
 ---
+import type { MarkdownLayoutProps } from 'astro'
+import type { LayoutOverridesHTMLAttributes } from '../libs/layout'
 import BaseLayout from './BaseLayout.astro'
+
+// TODO(HiDeoo) Depending on the routing implementation, the partial may not be needed.
+type Props = Partial<
+  MarkdownLayoutProps<{
+    toc?: boolean
+  }>
+>
+
+const { frontmatter } = Astro.props
+
+const bodyProps: LayoutOverridesHTMLAttributes<'body'> = { tabindex: 0 }
+
+if (frontmatter?.toc) {
+  bodyProps['data-bs-spy'] = 'scroll'
+  bodyProps['data-bs-target'] = '#TableOfContents'
+}
 ---
 
-<BaseLayout {...Astro.props} layout="docs" />
+<BaseLayout {...Astro.props} layout="docs" overrides={{ body: bodyProps }} />

--- a/site-new/src/layouts/DocsLayout.astro
+++ b/site-new/src/layouts/DocsLayout.astro
@@ -2,4 +2,4 @@
 import BaseLayout from './BaseLayout.astro'
 ---
 
-<BaseLayout layout="docs" />
+<BaseLayout {...Astro.props} layout="docs" />

--- a/site-new/src/libs/layout.ts
+++ b/site-new/src/libs/layout.ts
@@ -1,3 +1,9 @@
+import type { HTMLAttributes, HTMLTag } from 'astro/types'
+
 // TODO(HiDeoo) Not sure yet if a union of literal strings is the best way to handle this, need to see more of the
 // current usage in the existing docs but it's at least strictly typed for now.
 export type Layout = 'docs' | 'examples' | undefined
+
+export type LayoutOverridesHTMLAttributes<TTag extends HTMLTag> = HTMLAttributes<TTag> & {
+  [key in `data-${string}`]: string
+}

--- a/site-new/src/pages/404.astro
+++ b/site-new/src/pages/404.astro
@@ -3,7 +3,6 @@ import BaseLayout from '../layouts/BaseLayout.astro'
 
 /*
  TODO: missing elements from Bootstrap's frontmatter
-  - title: "404 - File not found"
   - description: ""
   - url: /404.html
   - sitemap_exclude: true
@@ -33,6 +32,7 @@ import BaseLayout from '../layouts/BaseLayout.astro'
     main: { class: 'my-auto p-5', id: 'content' },
   }}
   robots="noindex,follow"
+  title="404 - File not found"
 >
   <div class="text-center py-5">
     <h1 class="display-1">404</h1>

--- a/site-new/src/pages/404.astro
+++ b/site-new/src/pages/404.astro
@@ -12,8 +12,6 @@ import BaseLayout from '../layouts/BaseLayout.astro'
 /*
  TODO: Be able to override <body>
   - Note: {{ define "body_override" }} is used in site/layouts/_default/ files:
-    - 404.html
-    - baseof.html
     - docs.html
 
   {{ define "body_override" }}<body class="d-flex flex-column min-vh-100">{{ end }}
@@ -21,21 +19,21 @@ import BaseLayout from '../layouts/BaseLayout.astro'
 
 /*
  TODO: Be able to override <main>
+ TODO(HiDeoo) The remaining elements in this todo may not require overrides but just a dedicated layout.
   - Note: {{ define "main" }} is used in site/layouts/_default/ files:
-    - 404.html
     - docs.html
     - home.html
     - single.html
-
-  {{ define "main" }}
-    <main class="my-auto p-5" id="content">
-      {{ .Content }}
-    </main>
-  {{ end }}
 */
 ---
 
-<BaseLayout robots="noindex,follow">
+<BaseLayout
+  overrides={{
+    body: { class: 'd-flex flex-column min-vh-100' },
+    main: { class: 'my-auto p-5', id: 'content' },
+  }}
+  robots="noindex,follow"
+>
   <div class="text-center py-5">
     <h1 class="display-1">404</h1>
     <h2>File not found</h2>

--- a/site-new/src/pages/404.astro
+++ b/site-new/src/pages/404.astro
@@ -8,14 +8,6 @@ import BaseLayout from '../layouts/BaseLayout.astro'
 */
 
 /*
- TODO: Be able to override <body>
-  - Note: {{ define "body_override" }} is used in site/layouts/_default/ files:
-    - docs.html
-
-  {{ define "body_override" }}<body class="d-flex flex-column min-vh-100">{{ end }}
-*/
-
-/*
  TODO: Be able to override <main>
  TODO(HiDeoo) The remaining elements in this todo may not require overrides but just a dedicated layout.
   - Note: {{ define "main" }} is used in site/layouts/_default/ files:

--- a/site-new/src/pages/404.astro
+++ b/site-new/src/pages/404.astro
@@ -3,7 +3,6 @@ import BaseLayout from '../layouts/BaseLayout.astro'
 
 /*
  TODO: missing elements from Bootstrap's frontmatter
-  - description: ""
   - url: /404.html
   - sitemap_exclude: true
 */

--- a/site-new/src/pages/index.astro
+++ b/site-new/src/pages/index.astro
@@ -1,72 +1,17 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro'
-import Ads from '../components/Ads.astro'
 import GetStarted from '../components/home/GetStarted.astro'
 import Customize from '../components/home/Customize.astro'
 import CSSVariables from '../components/home/CSSVariables.astro'
 import ComponentUtilities from '../components/home/ComponentUtilities.astro'
+import MastHead from '../components/home/MastHead.astro'
 import Plugins from '../components/home/Plugins.astro'
 import Icons from '../components/home/Icons.astro'
 import Themes from '../components/home/Themes.astro'
-import { getConfig, getVersionedDocsPath } from '../libs/config'
 ---
 
 <BaseLayout>
-  <!--TODO: could be in a separate file. Was in "home/masthead.html" in Bootstrap-->
-  <div class="bd-masthead mb-3" id="content">
-    <div class="container-xxl bd-gutter">
-      <div class="col-md-8 mx-auto text-center">
-        <a
-          class="d-flex flex-column flex-lg-row justify-content-center align-items-center mb-4 text-dark lh-sm text-decoration-none"
-          href="https://blog.getbootstrap.com/"
-        >
-          <strong class="d-sm-inline-block p-2 me-2 mb-2 mb-lg-0 rounded-3 masthead-notice">New in v5.3</strong>
-          <span class="text-body-secondary">Color mode support, expanded color palette, and more!</span>
-        </a>
-        <img
-          src="/brand/bootstrap-logo-shadow.png"
-          width="200"
-          height="165"
-          alt="Bootstrap"
-          class="d-none d-sm-block mx-auto mb-3"
-        />
-        <h1 class="mb-3 fw-semibold lh-1">Build fast, responsive sites with&nbsp;Bootstrap</h1>
-        <p class="lead mb-4">
-          Powerful, extensible, and feature-packed frontend toolkit. Build and customize with Sass, utilize prebuilt
-          grid system and components, and bring projects to life with powerful JavaScript plugins.
-        </p>
-        <div class="d-flex flex-column flex-lg-row align-items-md-stretch justify-content-md-center gap-3 mb-4">
-          <div class="d-inline-block v-align-middle fs-5">
-            <!-- TODO: replace by Astro stuff
-              * 'highlight' is a feature provided by Hugo
-              * We use Chroma style overriden in _syntax.scss
-            -->
-            <!-- {{ highlight (printf ("npm i bootstrap@%s") .Site.Params.current_version) "sh" "" }} -->
-          </div>
-          <a
-            href={getVersionedDocsPath('getting-started/introduction')}
-            class="btn btn-lg bd-btn-lg btn-bd-primary d-flex align-items-center justify-content-center fw-semibold"
-            onclick="ga('send', 'event', 'Jumbotron actions', 'Get started', 'Get started');"
-          >
-            <svg class="bi me-2" aria-hidden="true"><use xlink:href="#book-half"></use></svg>
-            Read the docs
-          </a>
-        </div>
-        <p class="text-body-secondary mb-0">
-          Currently <strong>v{getConfig().params.current_version}</strong>
-          <span class="px-1">&middot;</span>
-          <a href={getVersionedDocsPath('getting-started/download')} class="link-secondary">Download</a>
-          <span class="px-1">&middot;</span>
-          <a href="https://getbootstrap.com/docs/4.6/getting-started/introduction/" class="link-secondary text-nowrap"
-            >v4.6.x docs</a
-          >
-          <span class="px-1">&middot;</span>
-          <a href="/docs/versions/" class="link-secondary text-nowrap">All releases</a>
-        </p>
-        <Ads />
-      </div>
-    </div>
-  </div>
+  <MastHead />
   <div class="container-xxl bd-gutter masthead-followup">
     <!--TODO: Do we need to prefix their name? (e.g., HomeGetStarted, etc) -->
     <GetStarted />

--- a/site-new/src/pages/markdown.md
+++ b/site-new/src/pages/markdown.md
@@ -1,8 +1,9 @@
 ---
-layout: ../layouts/BaseLayout.astro
+layout: ../layouts/DocsLayout.astro
 title: Markdown page
 description: Amazing Markdown page
 thumbnail: 'test.png'
+toc: true
 ---
 
 This is a test page to test page titles, descriptions & thumbnails.


### PR DESCRIPTION
## Overrides

Any page using the base layout or any other layout using the base layout now has the ability to override HTML attributes for the `body` and `main` tags.

This is entirely typed, meaning you also get proper autocomplete for the attributes you can override and errors for invalid attributes.

<img width="726" alt="Screenshot 2023-02-22 at 17 40 09" src="https://user-images.githubusercontent.com/494699/220696751-74fa1934-985d-4efd-b1e2-7dab74aa41d3.png">

## Base layout props documentation

I tried to comment the props available to the base layout, so that it's easier to understand what's going on.