### PR TITLE
Shortcodes

### DIFF
--- a/site-new/src/components/shortcodes/JsDismiss.astro
+++ b/site-new/src/components/shortcodes/JsDismiss.astro
@@ -1,0 +1,27 @@
+---
+interface Props {
+  name: string
+}
+
+const { name } = Astro.props
+---
+
+<p>
+  Dismissal can be achieved with the <code>data</code> attribute on a button <strong>within the {name}</strong> as demonstrated
+  below:
+</p>
+
+<div>// TODO(HiDeoo) add code</div>
+
+<!-- ```html
+<button type="button" class="btn-close" data-bs-dismiss="{{ $name }}" aria-label="Close"></button>
+``` -->
+
+<p>or on a button <strong>outside the {name}</strong> using the <code>data-bs-target</code> as demonstrated below:</p>
+
+<div>// TODO(HiDeoo) add code</div>
+
+<!-- ```html
+<button type="button" class="btn-close" data-bs-dismiss="{{ $name }}" data-bs-target="#my-{{ $name }}" aria-label="Close"></button>
+```
+ -->

--- a/site-new/src/components/shortcodes/Placeholder.astro
+++ b/site-new/src/components/shortcodes/Placeholder.astro
@@ -1,69 +1,134 @@
 ---
 import { getGrays } from '../../libs/data/grays'
 
-/*
-  Usage: `placeholder args`
-
-  `args` are all optional and can be one of the following:
-    * title: Used in the SVG `title` tag - default: "Placeholder"
-    * text: The text to show in the image - default: "${width}x{$height)"
-    * classes: Class to add to the `svg` or `img` - default: "bd-placeholder-img"
-    * color: The text color (foreground) - default: "#dee2e6"
-    * background: The background color - default: "#868e96"
-    * width: default: "100%"
-    * height: default: "180"
-    * markup: If it should render `svg` or `img` tags - default: "svg"
-*/
-
 interface Props {
-  background: string,
-  classes: string,
-  color: string,
-  height: string,
-  markup: string,
-  text: string,
-  title: string,
-  width: string
+  /**
+   * The SVG background color.
+   * @default "#868e96"
+   */
+  background?: string
+  /**
+   * CSS classes to append to `bd-placeholder-img` for the `svg` or `img` elements.
+   */
+  class?: string
+  /**
+   * The text color (foreground).
+   * @default "#dee2e6"
+   */
+  color?: string
+  /**
+   * The placeholder height.
+   * @default "180"
+   */
+  height?: string
+  /**
+   * If it should render `svg` or `img` tags.
+   * @default "svg"
+   */
+  markup?: 'img' | 'svg'
+  /**
+   * The text to show in the image. You can explicitely pass the `false` boolean value (and not the string "false") to
+   * hide the text
+   * @default "${width}x{$height)"
+   */
+  text?: string | false
+  /**
+   * Used in the SVG `title` tag. You can explicitely pass the `false` boolean value (and not the string "false") to
+   * hide the title.
+   * @default "Placeholder"
+   */
+  title?: string | false
+  /**
+   * The placeholder width.
+   * @default "100%"
+   */
+  width?: string
 }
 
-// TODO: default value of text should be "default (printf "%sx%s" $width $height)"
 // TODO: double check the rendering of the grays (doubt about the index value compared to Hugo)
-const { background=getGrays()[5].hex, classes="bd-placeholder-img", color=getGrays()[2].hex, height="180", markup = 'svg', text='width x height', title = 'Placeholder', width="100%" } = Astro.props
+// TODO(HiDeoo) `getGrays()` should be refactored to not rely on indexes but have strictly typed values to use, e.g. `getGrays().100` or `getGrays('100')`.
+// TODO(HiDeoo) After migrating the docs, make sure this is never called with the "false" string.
+const {
+  background = getGrays()[5].hex,
+  class: className,
+  color = getGrays()[2].hex,
+  height = '180',
+  markup = 'svg',
+  text,
+  title = 'Placeholder',
+  width = '100%',
+} = Astro.props
+
+const placeholderText = text ?? `${width}x${height}`
+
+const showText = placeholderText !== false
+const showTitle = title !== false
+
+const placeholderClassList = ['bd-placeholder-img', className]
+const placeholderRole = showTitle || showText ? 'img' : undefined
+const placeholderAriaHidden = !showText && !showTitle ? 'true' : undefined
+
+const placeholderLabel =
+  showText || showTitle
+    ? `${showTitle ? title : ''}${showTitle && showText ? ': ' : ''}${showText ? placeholderText : ''}`
+    : undefined
+
+function getPlaceholderSrc() {
+  // Sanitize the background and text colors by removing the leading hash if any.
+  const bgColor = background.replace(/^#/, '')
+  const textColor = color.replace(/^#/, '')
+
+  // Inline the SVG with the `data:` URI scheme.
+  let placeholderSrc = `data:image/svg+xml,%3Csvg%20style='font-size:%201.125rem;%20font-family:system-ui,-apple-system,%22Segoe%20UI%22,Roboto,%22Helvetica%20Neue%22,%22Noto%20Sans%22,%22Liberation%20Sans%22,Arial,sans-serif,%22Apple%20Color%20Emoji%22,%22Segoe%20UI%20Emoji%22,%22Segoe%20UI%20Symbol%22,%22Noto%20Color%20Emoji%22;%20-webkit-user-select:%20none;%20-moz-user-select:%20none;%20user-select:%20none;%20text-anchor:%20middle;'%20width='200'%20height='200'%20xmlns='http://www.w3.org/2000/svg'%3E`
+
+  if (showTitle) {
+    // Append the <title> tag if any.
+    placeholderSrc = `${placeholderSrc}%3Ctitle%3E${title}%3C/title%3E`
+  }
+
+  // Fill the image rect with the expected background color.
+  placeholderSrc = `${placeholderSrc}%3Crect%20width='100%25'%20height='100%25'%20fill='%23${bgColor}'%3E%3C/rect%3E`
+
+  if (showText) {
+    // Append the <text> tag if any with the expected color.
+    placeholderSrc = `${placeholderSrc}%3Ctext%20x='50%25'%20y='50%25'%20fill='%23${textColor}'%20dy='.3em'%3E${placeholderText}%3C/text%3E`
+  }
+
+  // Close the SVG.
+  placeholderSrc = `${placeholderSrc}%3C/svg%3E`
+
+  return placeholderSrc
+}
 ---
 
-<!--TODO: better syntax for `bd-placeholder-img${classes ? classes : ''}` both in <img> and <svg>?-->
 {
-  markup === 'img' ?
-  <img
-    class={`bd-placeholder-img${classes ? classes : ''}`}
-    alt={`${title} : ${text}`}
-    width={width}
-    height={height}
-    src={`data:image/svg+xml,%3Csvg%20style='font-size:%201.125rem;%20font-family:system-ui,-apple-system,%22Segoe%20UI%22,Roboto,%22Helvetica%20Neue%22,%22Noto%20Sans%22,%22Liberation%20Sans%22,Arial,sans-serif,%22Apple%20Color%20Emoji%22,%22Segoe%20UI%20Emoji%22,%22Segoe%20UI%20Symbol%22,%22Noto%20Color%20Emoji%22;%20-webkit-user-select:%20none;%20-moz-user-select:%20none;%20user-select:%20none;%20text-anchor:%20middle;'%20width='200'%20height='200'%20xmlns='http://www.w3.org/2000/svg'%3E
-    ${(title !== "false" ? ("%3Ctitle%3E" + title + "%3C/title%3E") : "")}
-    %3Crect%20width='100%25'%20height='100%25'%20fill='%23dee2e6'%3E%3C/rect%3E
-    ${(text !== "false" ? ("%3Ctext%20x='50%25'%20y='50%25'%20fill='%23868e96'%20dy='.3em'%3E" + text + "%3C/text%3E") : undefined)}
-    %3C/svg%3E`}
-  />
-  :
-  <svg xmlns="http://www.w3.org/2000/svg"
-    class={`bd-placeholder-img${classes ? classes : ''}`}
-    width={width}
-    height={height}
-    role={(title !== "false" || text !== "false") ? "img" : undefined}
-    aria-label={(title !== "false" || text !== "false") ?
-    ((title!=="false" ? title + (text !== "false" ? ': ' : '') : "") + (text !== "false" ? text : ""))
-    : undefined
-    }
-    aria-hidden={!(title !== "false" || text !== "false") ? true : false}
-    preserveAspectRatio="xMidYMid slice" focusable="false">
-    {
-      title !== "false" && <title>{title}</title>
-    }
-    <rect width="100%" height="100%" fill={background}/>
-    {
-      text !== "false" && <text x="50%" y="50%" fill={color} dy=".3em">{text}</text>
-    }
-  </svg>
+  markup === 'img' ? (
+    <img
+      alt={placeholderLabel}
+      class:list={placeholderClassList}
+      height={height}
+      src={getPlaceholderSrc()}
+      width={width}
+    />
+  ) : (
+    <svg
+      aria-hidden={placeholderAriaHidden}
+      aria-label={placeholderLabel}
+      class:list={placeholderClassList}
+      focusable="false"
+      height={height}
+      preserveAspectRatio="xMidYMid slice"
+      role={placeholderRole}
+      width={width}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {showTitle && <title>{title}</title>}
+      <rect width="100%" height="100%" fill={background} />
+      {showText && (
+        <text x="50%" y="50%" fill={color} dy=".3em">
+          {placeholderText}
+        </text>
+      )}
+    </svg>
+  )
 }
-

--- a/site-new/src/pages/markdown.mdx
+++ b/site-new/src/pages/markdown.mdx
@@ -9,6 +9,7 @@ import AddedIn from '../components/shortcodes/AddedIn.astro';
 import CalloutDeprecatedDarkVariants from '../components/shortcodes/CalloutDeprecatedDarkVariants.astro';
 import Callout from '../components/shortcodes/Callout.astro';
 import DeprecatedIn from '../components/shortcodes/DeprecatedIn.astro';
+import JsDismiss from '../components/shortcodes/JsDismiss.astro';
 import Placeholder from '../components/shortcodes/Placeholder.astro';
 
 {/* TODO: change layout to DocsLayout.astro */}
@@ -46,7 +47,7 @@ TODO: "docsref"
 TODO: "example"
 
 # JsDismiss
-TODO: "js-dismiss"
+<JsDismiss name="alert" />
 
 # Markdown
 TODO: "markdown"


### PR DESCRIPTION
As we discussed on Discord, this PR is mostly how I would have coded some shortcodes. You don't have to merge it, you can throw it away after looking at it and picking what you like, if any, no questions asked.

### Placeholder

- Having logic in the JSX markup is usually fine altho, when there is a lot of it, it can be hard to read. The main goal here was to simplify the markup and move all the logic to the frontmatter in variables with really explicit names.
- The documentation has been updated to use the JSDoc format and fix various issues in it.
- Everything is properly typed.
- The `classes` parameter has been renamed to `class`. You were properly using `class` (the Astro way of doing things) in `markdown.mdx` but still using `classes` in the component so this was not working.
- Properly added the default value for the text parameter (`${width}x${height}`)
- Logic to decide if a title or text is visible is done through an explicit `false` boolean value and no longer a `"false"` string (documented explicitely).
- The image `alt` attribute is now the same as the svg `aria-label` as you could end up with the `"false : something"` `alt` attribute which is not the intended behavior I think and was already properly handled by the `aria-label` attribute.
- The image `src` is now no longer a huge unreadable string concatenation. Sometimes using basic `if` statements is better for readability and I think this is a good example of that. With a quick read of the `getPlaceholderSrc` function, you get a good idea of what the `src` attribute will look like and what is being done.
- When using the `img` markup format, the background and foreground colors are now respecting the passed down values instead of being hardcoded.
- I also added 2 todos, one for a refactor and one for a check after migrating the documentation.

### JsDismiss

Nothing much here as the part related to the code block is related to what I briefly started yesterday and stashed away before your stream. I added back the 2 sentences in the meantime and added todos for the 2 code blocks.